### PR TITLE
Update test case to use the correct PGP/MIME type.

### DIFF
--- a/src/javascript/crypto/e2e/openpgp/pgpmime/constants.js
+++ b/src/javascript/crypto/e2e/openpgp/pgpmime/constants.js
@@ -121,6 +121,7 @@ e2e.openpgp.pgpmime.Constants.Mime = {
 
   // Content dispositions
   ATTACHMENT: 'attachment',
+  INLINE: 'inline',
 
   // Charset. Case-insensitive.
   UTF8: 'utf-8',

--- a/src/javascript/crypto/e2e/openpgp/pgpmime/pgpmail.js
+++ b/src/javascript/crypto/e2e/openpgp/pgpmime/pgpmail.js
@@ -180,14 +180,14 @@ e2e.openpgp.pgpmime.PgpMail.prototype.buildPGPMimeTree = function() {
         value: constants.Mime.PGP_MIME_DESCRIPTION}]});
   versionNode.setContent(constants.Mime.VERSION_CONTENT);
 
-  // Set the ciphertext. Due to Gmail bug, we use constants.Mime.PLAINTEXT
-  // instead of constants.Mime.OCTET_STREAM for contentType
   var contentNode = rootNode.addChild({multipart: false,
     optionalHeaders: [
       {name: constants.Mime.CONTENT_TYPE,
-        value: constants.Mime.PLAINTEXT,
-        params: {'charset': constants.Mime.UTF8,
-          'name': constants.Mime.ENCRYPTED_ASC}},
+        value: constants.Mime.OCTET_STREAM,
+        params: {'name': constants.Mime.ENCRYPTED_ASC}},
+      {name: constants.Mime.CONTENT_DISPOSITION,
+        value: constants.Mime.INLINE,
+        params: {'name': constants.Mime.ENCRYPTED_ASC}},
       {name: constants.Mime.CONTENT_TRANSFER_ENCODING,
         value: constants.Mime.SEVEN_BIT}]});
   contentNode.setContent(this.content.body);

--- a/src/javascript/crypto/e2e/openpgp/pgpmime/pgpmail_test.js
+++ b/src/javascript/crypto/e2e/openpgp/pgpmime/pgpmail_test.js
@@ -166,8 +166,8 @@ function testBuildPGPMimeTree() {
     ' version.asc"', 'Content-Transfer-Encoding: 7bit',
     'Content-Description: PGP/MIME Versions Identification', '',
     'Version: 1', '----foo',
-    'Content-Type: text/plain; charset="utf-8"; ' +
-        'name="encrypted.asc"',
+    'Content-Type: application/octet-stream; name="encrypted.asc"',
+    'Content-Disposition: inline; name="encrypted.asc"',
     'Content-Transfer-Encoding: 7bit', '', 'some encrypted text',
     '----foo--', ''].join('\r\n');
   var encryptedText = 'some encrypted text';


### PR DESCRIPTION
Remove Gmail workarounds and create correct PGP/MIME content.
